### PR TITLE
Fix #5 and improve documentation quality

### DIFF
--- a/kpi-calculation.ipynb
+++ b/kpi-calculation.ipynb
@@ -372,11 +372,16 @@
     "\n",
     "This uses the example request from the [documentation](https://developer.mindsphere.io/apis/analytics-kpicalculation/api-kpicalculation-samples.html#determining-unit-states-from-sensor-control-unit-and-calendar-data) for calculation\n",
     "\n",
-    "This sample provides a generic procedure for determining the State of a compressor with a pressure sensor, events from the compressor control unit and a maintenance calendar.\n",
+    "This sample provides a generic procedure for determining the state of a compressor with a pressure sensor, events from the compressor control unit, and a maintenance calendar.\n",
     "                                                       \n",
     "![](https://developer.mindsphere.io/apis/analytics-kpicalculation/images/Use-case-2-Example.png)\n",
     "\n",
-    "## Calculate the states"
+    "## Calculate the states\n",
+    "\n",
+    "In this section the [KPI state calculations](https://developer.mindsphere.io/apis/analytics-kpicalculation/api-kpicalculation-basics-kpi-states.html) are calculated with measurement data taken from correctly formatted JSON files.\n",
+    "* **Sensor Readings** are taken from `sample-timeseries.json` file with the `sensor` column used as the target variable. Sensor readings must be in numeric form.\n",
+    "* **Calendar Entries** are taken from `calendar.json` file.\n",
+    "* **Control System Events** are taken from `sample-events.json` file."
    ]
   },
   {
@@ -881,7 +886,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Calculate kpis for compressor"
+    "## Calculate kpis for compressor\n",
+    "\n",
+    "In this section the [KPIs](https://developer.mindsphere.io/apis/analytics-kpicalculation/api-kpicalculation-basics-kpi.html) are computed with the state data calculated within the previous section.\n",
+    "* **State KPIs** are taken from `compressor-states.json` file with the `state` column used as the target variable.\n"
    ]
   },
   {
@@ -928,7 +936,7 @@
     "!mc kpi-calculation \\\n",
     "--mode kpis \\\n",
     "--file \"temp/compressor-states.json\" \\\n",
-    "--target kpistatus \\\n",
+    "--target state \\\n",
     "--initialstate RSH \\\n",
     "--passkey $passkey \\\n",
     "> temp/kpi-compressor.json\n",


### PR DESCRIPTION
## What?
Fixes #5 and improves documentation.
## Why?
The `kpi-calculation.ipynb` contains an error with an incorrect target variable specified in the API call. Furthermore, additional clarity has been added regarding what data is used in the API calls and what target variable is used.
## Screenshots
### Documentation Changes
![Change1](https://user-images.githubusercontent.com/23283793/115932082-23e85880-a484-11eb-984f-4f388be74bb7.png)
![Change2](https://user-images.githubusercontent.com/23283793/115932083-2480ef00-a484-11eb-8aae-942e7db5b7ae.png)
## Other 
This work was conducted as part of Group 4 of University of Sheffield's Department of Automatic Control and Systems Engineering MEng group project. The group is grateful for the use of the Mindsphere open source tools. 